### PR TITLE
Bugfix to address upstream changes to sqlcmd path and options causing healthcheck to fail

### DIFF
--- a/.github/workflows/pr-mssql-tests.yml
+++ b/.github/workflows/pr-mssql-tests.yml
@@ -38,7 +38,7 @@ jobs:
           version: dev
           sync: false
       - name: Setup lando ${{ matrix.lando-version }}
-        uses: lando/setup-lando@v2
+        uses: lando/setup-lando@v3
         with:
           lando-version: ${{ matrix.lando-version }}
           config: |

--- a/.github/workflows/pr-mssql-tests.yml
+++ b/.github/workflows/pr-mssql-tests.yml
@@ -14,6 +14,7 @@ jobs:
         leia-test:
           - examples/2017
           - examples/2019
+          - examples/2022
         lando-version:
           - 3-dev-slim
         os:

--- a/.lando.yml
+++ b/.lando.yml
@@ -1,7 +1,9 @@
 name: lando-mssql-plugin
 services:
   node:
-    type: node:18
+    type: lando
+    services:
+      image: node:18
     build:
       - npm install
     scanner: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+* Bugfix to address upstream changes to `sqlcmd` path and options causing healthcheck to fail. [#35](https://github.com/lando/mssql/issues/35)
+
 ## v1.2.0 - [July 1, 2024](https://github.com/lando/mssql/releases/tag/v1.2.0)
 
 * Updated to add support for SQL Server 2022. [#34](https://github.com/lando/mssql/issues/34)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
-* Bugfix to address upstream changes to `sqlcmd` path and options causing healthcheck to fail. [#35](https://github.com/lando/mssql/issues/35)
+* Bugfix to address upstream changes to `sqlcmd` path and options causing healthcheck to fail. [#37](https://github.com/lando/mssql/pull/37)
 
 ## v1.2.0 - [July 1, 2024](https://github.com/lando/mssql/releases/tag/v1.2.0)
 

--- a/builders/mssql.js
+++ b/builders/mssql.js
@@ -21,6 +21,7 @@ module.exports = {
       '/sbin',
       '/bin',
       '/opt/mssql-tools/bin',
+      '/opt/mssql-tools18/bin',
     ],
     port: '1433',
   },

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,7 @@ services:
 
 * [2022-latest](https://hub.docker.com/_/microsoft-mssql-server)  
 * [2019-latest](https://hub.docker.com/_/microsoft-mssql-server)
+* [2022-latest](https://hub.docker.com/_/microsoft-mssql-server)
 *   **[2017-latest](https://hub.docker.com/_/microsoft-mssql-server)** **(default)**
 *   [custom](https://docs.lando.dev/core/v3/lando-service.html#overrides)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,6 @@ services:
 
 * [2022-latest](https://hub.docker.com/_/microsoft-mssql-server)  
 * [2019-latest](https://hub.docker.com/_/microsoft-mssql-server)
-* [2022-latest](https://hub.docker.com/_/microsoft-mssql-server)
 *   **[2017-latest](https://hub.docker.com/_/microsoft-mssql-server)** **(default)**
 *   [custom](https://docs.lando.dev/core/v3/lando-service.html#overrides)
 

--- a/examples/2017/README.md
+++ b/examples/2017/README.md
@@ -23,7 +23,7 @@ Run the following commands to validate things are rolling as they should.
 
 ```bash
 # Should be able to connect
-lando ssh -s defaults -c "sqlcmd -U sa -H database -P he11oTHERE -Q quit"
+lando ssh -s defaults -c "sqlcmd -U sa -H database -P he11oTHERE -Q quit -C"
 ```
 
 Destroy tests

--- a/examples/2019/README.md
+++ b/examples/2019/README.md
@@ -23,7 +23,7 @@ Run the following commands to validate things are rolling as they should.
 
 ```bash
 # Should be able to connect
-lando ssh -s defaults -c "sqlcmd -U sa -H database -P he11oTHERE -Q quit"
+lando ssh -s defaults -c "sqlcmd -U sa -H database -P he11oTHERE -Q quit -C"
 ```
 
 Destroy tests

--- a/examples/2022/README.md
+++ b/examples/2022/README.md
@@ -23,7 +23,7 @@ Run the following commands to validate things are rolling as they should.
 
 ```bash
 # Should be able to connect
-lando ssh -s defaults -c "sqlcmd -U sa -H database -P he11oTHERE -Q quit"
+lando ssh -s defaults -c "sqlcmd -U sa -H database -P he11oTHERE -Q quit -C"
 ```
 
 Destroy tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@lando/mssql",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "GPL-3.0",
       "dependencies": {
         "lodash": "^4.17.21"

--- a/utils/get-default-healthcheck.js
+++ b/utils/get-default-healthcheck.js
@@ -8,5 +8,6 @@ module.exports = options => {
     `-H ${options.name}`,
     `-P ${options.creds.password}`,
     `-Q quit`,
+    `-C`,
   ].join(' ');
 };


### PR DESCRIPTION
This PR fixes #36 

### Bare minimum self-checks

> [What do you think of a person who only does the bare minimum?](https://getyarn.io/yarn-clip/dcf80710-425e-478b-bde1-c107bd11e849)

- [x] I've updated this PR with the latest code from `main`
- [x] I've done a cursory QA pass of my code locally
- [x] I've ensured all automated status check and tests pass
- [x] I've [connected this PR to an issue](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues)

### Pieces of flare

- [ ] I've written a unit or functional test for my code
- [ ] I've updated relevant documentation it my code changes it
- [ ] I've updated this repo's README if my code changes it
- [x] I've updated this repo's CHANGELOG with my change unless its a trivial change (like updating a typo in the docs)

### Finally

- [ ] I've [requested a review](https://help.github.com/en/articles/requesting-a-pull-request-review) with relevant people

If you have any issues or need help please join the `#contributors` channel in the [Lando slack](https://www.launchpass.com/devwithlando) and someone will gladly help you out!

You can also check out the [coder guide](https://docs.lando.dev/contrib/coder.html).
